### PR TITLE
adding support for multiple methods

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Test-TinyMocker
 
+0.03
+        [Sawyer X]
+        * Supporting arrayrefs for multiple methods, adding "methods".
+
 0.02	08/24/2010
 		[Jérôme Bourgeois]
 		* Support for the 'unmock' function.

--- a/MANIFEST
+++ b/MANIFEST
@@ -13,6 +13,8 @@ t/01_mock.t
 t/02_unmock.t
 t/03_mock_error.t
 t/04_unmock_error.t
+t/05_multiple_mock.t
+t/06_multiple_unmock.t
 t/manifest.t
 t/pod-coverage.t
 t/pod.t

--- a/lib/Test/TinyMocker.pm
+++ b/lib/Test/TinyMocker.pm
@@ -114,6 +114,14 @@ Version 0.02
             return $mocked_value;
         };
 
+    # or
+
+    mock 'Some::Module'
+        => methods [ 'this_method', 'that_method' ]
+        => should {
+            return $mocked_value;
+        };
+
     # or 
 
     mock 'Some::Module::some_method'
@@ -130,11 +138,14 @@ Version 0.02
 	# or
 	
 	unmock 'Some::Module' => method 'some_method';
-	
+
+    # or
+
+    unmock 'Some::Module' => methods [ 'this_method', 'that_method' ];
 
 =head1 EXPORT
 
-=head2 mock($module, $method, $sub)
+=head2 mock($module, $method_or_methods, $sub)
 
 This function allows you to overwrite the given method with an arbitrary code
 block. This lets you simulate soem kind of behaviour for your tests.
@@ -143,8 +154,8 @@ Alternatively, this method can be passed only two arguments, the first one will
 be the full path of the method (pcakge name + method name) and the second one
 the coderef.
 
-Syntactic sugar is provided (C<method> and C<should>) in order to let you write
-sweet mock statements:
+Syntactic sugar is provided (C<method>, C<methods> and C<should>) in order to
+let you write sweet mock statements:
 
     # This:
     mock('Foo::Bar', 'a_method', sub { return 42;});
@@ -158,10 +169,18 @@ sweet mock statements:
     # or also:
     mock('Foo::Bar::a_method', sub { return 42;});
 
-=head2 unmock($module, $method)
+Using multiple methods at the same time can be done with arrayrefs:
 
-Syntactic sugar is provided (C<method>) in order to let you write sweet unmock
-statements:
+    # This:
+    mock('Foo::Bar', ['a_method', 'b_method'], sub { 42 } );
+
+    # is the same as:
+    mock 'Foo::Bar' => methods ['a_method', 'b_method'] => should { 42 };
+
+=head2 unmock($module, $method_or_methods)
+
+Syntactic sugar is provided (C<method> and C<methods>) in order to let you write
+sweet unmock statements:
 
     # This:
     unmock('Foo::Bar', 'a_method');
@@ -169,7 +188,15 @@ statements:
     # is the same as:
     unmock 'Foo::Bar' => method 'a_method';
 
+And using multiple methods at the same time:
+
+    unmock 'Foo::Bar' => methods ['a_method', 'b_method'];
+
 =head2 method
+
+Syntactic sugar for mock()
+
+=head2 methods
 
 Syntactic sugar for mock()
 

--- a/lib/Test/TinyMocker.pm
+++ b/lib/Test/TinyMocker.pm
@@ -21,7 +21,7 @@ sub mock {
     croak 'useless use of mock with one or less parameter'
       if scalar @_ < 2;
 
-    my @symbols;
+    my @symbols = ();
 
     if ( @_ > 2 ) {
         @symbols = ref $_[1] eq 'ARRAY'             ?

--- a/lib/Test/TinyMocker.pm
+++ b/lib/Test/TinyMocker.pm
@@ -11,23 +11,37 @@ use base 'Exporter';
 $VERSION = '0.02';
 my $mocks = {};
 
-@EXPORT = qw(mock unmock should method);
+@EXPORT = qw(mock unmock should method methods);
 
-sub method($) {@_}
-sub should(&) {@_}
+sub method($)  {@_}
+sub methods($) {@_}
+sub should(&)  {@_}
 
 sub mock {
     croak 'useless use of mock with one or less parameter'
       if scalar @_ < 2;
 
-    my $symbol = @_ > 2 ? qq{$_[0]::$_[1]} : $_[0];
+    my @symbols;
+
+    if ( @_ > 2 ) {
+        @symbols = ref $_[1] eq 'ARRAY'             ?
+                   map { qq{$_[0]::$_} } @{ $_[1] } :
+                   qq{$_[0]::$_[1]};
+    } else {
+        @symbols = ref $_[0] eq 'ARRAY' ?
+                   @{ $_[0] }           :
+                   $_[0];
+    }
+
     my $sub = $_[-1];
 
-    croak "unknown symbol : $symbol"
-      unless _symbol_exists($symbol);
+    foreach my $symbol (@symbols) {
+        croak "unknown symbol : $symbol"
+          unless _symbol_exists($symbol);
 
-    _save_sub($symbol);
-    _bind_coderef_to_symbol($symbol, $sub);
+        _save_sub($symbol);
+        _bind_coderef_to_symbol($symbol, $sub);
+    }
 }
 
 sub unmock {

--- a/lib/Test/TinyMocker.pm
+++ b/lib/Test/TinyMocker.pm
@@ -36,7 +36,7 @@ sub mock {
     my $sub = $_[-1];
 
     foreach my $symbol (@symbols) {
-        croak "unknown symbol : $symbol"
+        croak "unknown symbol: $symbol"
           unless _symbol_exists($symbol);
 
         _save_sub($symbol);

--- a/lib/Test/TinyMocker.pm
+++ b/lib/Test/TinyMocker.pm
@@ -45,19 +45,18 @@ sub mock {
 }
 
 sub unmock {
-
     croak 'useless use of unmock without parameters'
       unless scalar @_;
 
-    my $symbole = @_ == 2 ? qq{$_[0]::$_[1]} : $_[0];
+    my $symbol = @_ == 2 ? qq{$_[0]::$_[1]} : $_[0];
 
-    croak "unkown method $symbole"
-      unless $mocks->{$symbole};
+    croak "unkown method $symbol"
+      unless $mocks->{$symbol};
 
     {
         no strict 'refs';
         no warnings 'redefine', 'prototype';
-        *{$symbole} = delete $mocks->{$symbole};
+        *{$symbol} = delete $mocks->{$symbol};
     }
 }
 

--- a/lib/Test/TinyMocker.pm
+++ b/lib/Test/TinyMocker.pm
@@ -48,15 +48,26 @@ sub unmock {
     croak 'useless use of unmock without parameters'
       unless scalar @_;
 
-    my $symbol = @_ == 2 ? qq{$_[0]::$_[1]} : $_[0];
+    my @symbols = ();
+    if ( @_ == 2 ) {
+        @symbols = ref $_[1] eq 'ARRAY'             ?
+                   map { qq{$_[0]::$_} } @{ $_[1] } :
+                   qq{$_[0]::$_[1]};
+    } else {
+        @symbols = ref $_[0] eq 'ARRAY' ?
+                   @{ $_[0] }           :
+                   $_[0];
+    }
 
-    croak "unkown method $symbol"
-      unless $mocks->{$symbol};
+    foreach my $symbol (@symbols) {
+        croak "unkown method $symbol"
+          unless $mocks->{$symbol};
 
-    {
-        no strict 'refs';
-        no warnings 'redefine', 'prototype';
-        *{$symbol} = delete $mocks->{$symbol};
+        {
+            no strict 'refs';
+            no warnings 'redefine', 'prototype';
+            *{$symbol} = delete $mocks->{$symbol};
+        }
     }
 }
 

--- a/t/01_mock.t
+++ b/t/01_mock.t
@@ -42,6 +42,6 @@ eval { mock 'Foo' };
 like( $@, qr{useless use of mock with one}, "no call of mock with one parameter" );
 
 eval { mock 'Foo::Bar' => method 'faked' =>  should { return } };
-like( $@, qr{unknown symbol :}, "no mock non exists function" );
+like( $@, qr{unknown symbol:}, "no mock non exists function" );
 
 done_testing;

--- a/t/03_mock_error.t
+++ b/t/03_mock_error.t
@@ -11,6 +11,6 @@ eval { mock 'Foo' };
 like( $@, qr{useless use of mock with one}, "no call of mock with one parameter" );
 
 eval { mock 'Foo::Bar' => method 'faked' =>  should { return } };
-like( $@, qr{unknown symbol :}, "no mock non exists function" );
+like( $@, qr{unknown symbol:}, "no mock non exists function" );
 
 done_testing;

--- a/t/05_multiple_mock.t
+++ b/t/05_multiple_mock.t
@@ -57,9 +57,9 @@ eval { mock ['Foo','Bar'] };
 like( $@, qr{useless use of mock with one}, "no call of mock with one parameter" );
 
 eval { mock 'Foo::Bar' => method 'faked' => should { return } };
-like( $@, qr{unknown symbol :}, "no mock non exists function" );
+like( $@, qr{unknown symbol:}, "no mock non exists function" );
 
 eval { mock 'Foo::Bar' => methods [ 'faked', 'baked' ] => should { return } };
-like( $@, qr{unknown symbol :}, "no mock non exists function" );
+like( $@, qr{unknown symbol:}, "no mock non exists function" );
 
 done_testing;

--- a/t/05_multiple_mock.t
+++ b/t/05_multiple_mock.t
@@ -1,0 +1,65 @@
+use strict;
+use warnings;
+
+# this covers the exact same stuff from 01-mock.t
+# but uses more than one method to override using "methods"
+
+use Test::More;
+use Test::TinyMocker;
+
+{
+    package Foo::Bar;
+    sub baz { "day" }
+    sub qux { "way" }
+}
+
+# original value
+is Foo::Bar::baz(), "day", "first initial value is ok";
+is Foo::Bar::qux(), "way", "second initial value is ok";
+
+# basic syntax
+mock('Foo::Bar', [ 'baz', 'qux' ], sub { return $_[0] + 1 });
+cmp_ok Foo::Bar::baz(1), '==', 2, "basic syntax for baz";
+cmp_ok Foo::Bar::qux(1), '==', 2, "basic syntax for qux";
+
+mock 'Foo::Bar' => methods ['baz','qux'] => should { "night" };
+is Foo::Bar::baz(), "night", "static mocked value for baz";
+is Foo::Bar::qux(), "night", "static mocked value for qux";
+
+my $counter = 0;
+
+mock 'Foo::Bar' 
+    => methods [ 'baz', 'qux' ]
+    => should { $counter++; };
+
+cmp_ok Foo::Bar::baz(), '==', 0, "dynamic mocked value for baz";
+cmp_ok Foo::Bar::qux(), '==', 1, "dynamic mocked value for qux";
+cmp_ok Foo::Bar::baz(), '==', 2, "dynamic mocked value for baz";
+cmp_ok Foo::Bar::qux(), '==', 3, "dynamic mocked value for qux";
+
+mock('Foo::Bar::baz', sub { return $_[0] + 3 });
+mock('Foo::Bar::qux', sub { return $_[0] + 3 });
+cmp_ok Foo::Bar::baz(1), '==', 4, "2 args syntax for baz";
+cmp_ok Foo::Bar::qux(1), '==', 4, "2 args syntax for qux";
+
+mock ['Foo::Bar::baz','Foo::Bar::qux']
+    => should { $_[0] + 2 };
+is Foo::Bar::baz(1), 3, "2 args syntax with sugar for baz";
+is Foo::Bar::qux(1), 3, "2 args syntax with sugar for qux";
+
+eval { mock };
+like( $@, qr{useless use of mock with one}, "no call of mock without parameter" );
+
+eval { mock 'Foo' };
+like( $@, qr{useless use of mock with one}, "no call of mock with one parameter" );
+
+eval { mock ['Foo','Bar'] };
+like( $@, qr{useless use of mock with one}, "no call of mock with one parameter" );
+
+eval { mock 'Foo::Bar' => method 'faked' => should { return } };
+like( $@, qr{unknown symbol :}, "no mock non exists function" );
+
+eval { mock 'Foo::Bar' => methods [ 'faked', 'baked' ] => should { return } };
+like( $@, qr{unknown symbol :}, "no mock non exists function" );
+
+done_testing;

--- a/t/06_multiple_unmock.t
+++ b/t/06_multiple_unmock.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+# this covers the exact same stuff from 02-unmock.t
+# but uses more than one method to override using "methods"
+
+use Test::More;
+use Test::TinyMocker;
+
+{
+    package Foo::Bar;
+    sub baz { "day" }
+    sub qux { "way" }
+}
+
+# original value
+is Foo::Bar::baz(), "day", "initial value for baz is ok";
+is Foo::Bar::qux(), "way", "initial value for qux is ok";
+
+# mock new comportement 
+mock('Foo::Bar', [ 'baz', 'qux' ], sub { return 'night' });
+
+# unmock
+unmock('Foo::Bar', [ 'baz', 'qux' ]);
+is Foo::Bar::baz(), "day", "original value for baz";
+is Foo::Bar::qux(), "way", "original value for qux";
+
+# mock new comportement 
+mock('Foo::Bar', [ 'baz', 'qux' ], sub { return 'night' });
+
+# unmock
+unmock(['Foo::Bar::baz','Foo::Bar::qux']);
+is Foo::Bar::baz(), "day", "original value for baz";
+is Foo::Bar::qux(), "way", "original value for qux";
+
+# mock new comportement 
+mock('Foo::Bar', ['baz', 'qux'], sub { return 'night' });
+
+# unmock
+unmock 'Foo::Bar' => methods [ 'baz', 'qux' ];
+is Foo::Bar::baz(), "day", "original value for baz";
+is Foo::Bar::qux(), "way", "original value for qux";
+
+done_testing;


### PR DESCRIPTION
hey

i wanted to be able to write less code by doing:
    mock 'This::Class'
        => methods ['this', 'that']
        => should { ... };

instead of writing the mocking twice, i added an arrayref option to it and syntactic sugar called "methods" (defined exactly the same way) to allow for this.

i also want to refactor some of the code, so i might do that later.
