### PR TITLE
Fix test failures in t/pod.t

### DIFF
--- a/lib/Test/TinyMocker.pm
+++ b/lib/Test/TinyMocker.pm
@@ -133,7 +133,7 @@ Test::TinyMocker - a very simple tool to mock external modules
 	
 	unmock 'Some::Module::some_method';
 
-	# or
+    # or
 	
 	unmock 'Some::Module' => method 'some_method';
 


### PR DESCRIPTION
The culprit was a spurious Unicode space.
