### PR TITLE
Allow temporary unmocking

### DIFF
--- a/t/08_tmp_unmock.t
+++ b/t/08_tmp_unmock.t
@@ -1,0 +1,40 @@
+# \author: Armand Leclercq
+# \file: 08_tmp_unmock.t
+# \date: Fri 23 Jan 2015 10:38:19 AM CET
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::TinyMocker;
+
+{
+    package Foo::Bar;
+    sub baz { "day" }
+}
+
+# original value
+is Foo::Bar::baz(), "day", "initial value is ok";
+
+# mock new comportement
+mock('Foo::Bar', 'baz', sub { return 'night' });
+
+# tmp_unmock
+unmock('Foo::Bar', 'baz');
+is Foo::Bar::baz(), "day", "original value";
+
+# mock new comportement
+mock('Foo::Bar', 'baz', sub { return 'night' });
+
+# tmp_unmock
+tmp_unmock('Foo::Bar::baz');
+is Foo::Bar::baz(), "day", "original value";
+
+# mock new comportement
+mock('Foo::Bar', 'baz', sub { return 'night' });
+
+# tmp_unmock
+tmp_unmock 'Foo::Bar' => method 'baz';
+is Foo::Bar::baz(), "day", "original value";
+
+done_testing;

--- a/t/09_remock.t
+++ b/t/09_remock.t
@@ -1,0 +1,38 @@
+# \author: Armand Leclercq
+# \file: 09_remock.t
+# \date: Fri 23 Jan 2015 10:39:57 AM CET
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::TinyMocker;
+
+{
+    package Foo::Bar;
+    sub baz { "day" }
+}
+
+# original value
+is Foo::Bar::baz(), "day", "initial value is ok";
+
+# mock new comportement
+mock('Foo::Bar', 'baz', sub { return 'night' });
+
+# unmock
+tmp_unmock('Foo::Bar', 'baz');
+is Foo::Bar::baz(), "day", "original value";
+
+# remock new comportement
+remock('Foo::Bar', 'baz');
+is Foo::Bar::baz(), "night", "mocked value";
+
+# unmock
+unmock('Foo::Bar::baz');
+is Foo::Bar::baz(), "day", "original value";
+
+# remock new comportement
+eval { remock('Foo::Bar', 'baz'); };
+like( $@, qr{unkown method}, "no recover nuknown method" );
+
+done_testing;


### PR DESCRIPTION
I added two methods in order to allow temporary unmocking of methods without the need of copying the mocking sub.
